### PR TITLE
fix(smtp_config): add no_mx_lookups to SmtpConfig

### DIFF
--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -35,7 +35,8 @@ defmodule Mailman.ExternalSmtpAdapter do
       port: config.port,
       ssl: config.ssl,
       tls: config.tls,
-      auth: config.auth
+      auth: config.auth,
+      no_mx_lookups: config.no_mx_lookups
     ]
   end
 
@@ -48,7 +49,8 @@ defmodule Mailman.ExternalSmtpAdapter do
       ssl: config.ssl,
       tls: config.tls,
       auth: config.auth,
-      hostname: config.hostname
+      hostname: config.hostname,
+      no_mx_lookups: config.no_mx_lookups
     ]
   end
 end

--- a/lib/mailman/smtp_config.ex
+++ b/lib/mailman/smtp_config.ex
@@ -11,8 +11,8 @@ defmodule Mailman.SmtpConfig do
     ssl: false,
     tls: :never,
     hostname: nil,
-    auth: :always
-
+    auth: :always,
+    no_mx_lookups: false
 end
 
 defimpl Mailman.Adapter, for: Mailman.SmtpConfig do


### PR DESCRIPTION
Just realized I could've made this a lot cleaner by adding that option to the SmtpConfig struct with a default value. 